### PR TITLE
Add TweetClaw OpenClaw source example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,10 +2,11 @@
 
 Worked examples cross-referenced from the specification (`spec/v1.0/`).
 
-| Path | Demonstrates |
-| ---- | ------------ |
-| `source-only/intro.mda` | A `.mda` source that uses every MDA-extended construct: extended frontmatter, inline `ai-script`, footnote relationship. |
-| `skill-md/intro/` | The compiled SKILL.md package equivalent of `source-only/intro.mda`. Exercises §07-targets/skill-md.md end to end. |
+| Path                                        | Demonstrates                                                                                                                                                   |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source-only/intro.mda`                     | A `.mda` source that uses every MDA-extended construct: extended frontmatter, inline `ai-script`, footnote relationship.                                       |
+| `source-only/tweetclaw-social-workflow.mda` | A `.mda` source for an OpenClaw-compatible SKILL.md workflow that collects X/Twitter evidence and keeps TweetClaw write-like actions behind explicit approval. |
+| `skill-md/intro/`                           | The compiled SKILL.md package equivalent of `source-only/intro.mda`. Exercises §07-targets/skill-md.md end to end.                                             |
 
 When the compiler ships, `mda compile examples/source-only/intro.mda --target skill-md --out examples/skill-md/intro` MUST produce a directory byte-equivalent to `skill-md/intro/`.
 

--- a/examples/source-only/tweetclaw-social-workflow.mda
+++ b/examples/source-only/tweetclaw-social-workflow.mda
@@ -1,0 +1,63 @@
+---
+name: tweetclaw-social-workflow
+description: MDA source for an OpenClaw-compatible TweetClaw workflow that collects X/Twitter evidence before drafting and keeps social-account writes behind explicit approval.
+title: TweetClaw Social Workflow
+doc-id: 31d4cf15-fd5b-41db-bd34-7bbf5a5cfe51
+author: MDA Example Contributors
+tags: [example, skill-md, openclaw, twitter, x-api, social-media]
+created-date: '2026-06-07T00:00:00Z'
+metadata:
+  mda:
+    version: '1.0.0'
+    requires:
+      runtime: ['openclaw>=2026.6.1', 'node>=22']
+      tools: ['Read', 'Bash']
+      network: ['registry.npmjs.org', 'xquik.com']
+      packages: ['@xquik/tweetclaw']
+  ai-script:
+    version: '1'
+    instructions: |
+      Use this document when an agent needs X/Twitter source evidence before drafting or reviewing social content.
+      Install and inspect TweetClaw through OpenClaw, keep credentials outside the skill package, and require operator approval before write-like actions.
+---
+
+# TweetClaw Social Workflow
+
+Use TweetClaw as an OpenClaw plugin when the agent needs reviewed X/Twitter
+source context before drafting, ranking, or scheduling social content. Install
+the runtime plugin from npm and inspect the loaded entry before using it:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+openclaw plugins inspect tweetclaw --runtime --json
+```
+
+## Evidence First
+
+Collect evidence before drafting. Good read-first jobs include search tweets,
+search tweet replies, follower export, user lookup, media download, monitor
+review, webhook review, and giveaway draw context. Preserve source URLs, tweet
+IDs, author handles, timestamps, and query terms so reviewers can trace the
+draft back to public evidence[^evidence-context].
+
+## Approval Boundary
+
+Treat post tweets, post tweet replies, direct messages, media upload, monitor
+creation, webhook changes, giveaway draws, follows, profile edits, and deletes as
+write-like social-account actions. Ask OpenClaw to show the structured request
+and require one-time operator approval before each write-like call[^approval-boundary].
+
+## Runtime Responsibilities
+
+Keep the skill package declarative. Store API keys, signing keys, and account
+configuration in OpenClaw's local config or secret store, never in the MDA source
+or compiled `SKILL.md`. Let the downstream drafting, scheduler, calendar,
+analytics, or publishing system keep ownership of voice, copy, timing, and
+calendar health. TweetClaw supplies source context and approval-gated X/Twitter
+actions through OpenClaw[^openclaw-runtime].
+
+[^evidence-context]: {"rel-type": "supports", "doc-id": "pre-draft-social-evidence", "rel-desc": "TweetClaw read tools supply source evidence before drafting"}
+
+[^approval-boundary]: {"rel-type": "supports", "doc-id": "tweetclaw-approval-boundary", "rel-desc": "Write-like TweetClaw actions require explicit OpenClaw approval"}
+
+[^openclaw-runtime]: {"rel-type": "references", "doc-id": "openclaw-plugin-runtime", "rel-desc": "OpenClaw installs and inspects the TweetClaw plugin runtime"}

--- a/scripts/validate-conformance.mjs
+++ b/scripts/validate-conformance.mjs
@@ -577,8 +577,13 @@ for (const entry of manifest.fixtures) {
 console.log(`\n${BOLD}3. Examples sanity${RESET}`);
 const sourceValidator = getValidator('schemas/frontmatter-source.schema.json');
 const skillValidator = getValidator('schemas/frontmatter-skill-md.schema.json');
+const sourceExamples = [
+	'examples/source-only/intro.mda',
+	'examples/source-only/node-tools.mda',
+	'examples/source-only/tweetclaw-social-workflow.mda',
+];
 
-for (const f of ['examples/source-only/intro.mda', 'examples/source-only/node-tools.mda']) {
+for (const f of sourceExamples) {
 	const fm = extractFrontmatter(readFileSync(join(REPO, f), 'utf8'));
 	if (sourceValidator(fm ?? {})) pass(`${f} valid against source schema`);
 	else


### PR DESCRIPTION
## Summary
- add a source-only MDA example for an OpenClaw-compatible TweetClaw social workflow
- document read-first X/Twitter evidence collection and explicit approval boundaries for write-like actions
- include the new example in the conformance runner example sanity list

## Validation
- pnpm install --frozen-lockfile --ignore-scripts
- pnpm -C apps/cli build
- node scripts/validate-conformance.mjs
- pnpm exec prettier --check examples/README.md scripts/validate-conformance.mjs
- pnpm exec prettier --check --parser markdown examples/source-only/tweetclaw-social-workflow.mda
- git diff --check